### PR TITLE
feat(Sanitizer): enhance sanitization with ProcessorConfigBuilder and…

### DIFF
--- a/src/AttributeHandler.php
+++ b/src/AttributeHandler.php
@@ -7,19 +7,21 @@ namespace KaririCode\PropertyInspector;
 use KaririCode\Contract\Processor\Attribute\CustomizableMessageAttribute;
 use KaririCode\Contract\Processor\Attribute\ProcessableAttribute;
 use KaririCode\Contract\Processor\ProcessorBuilder;
-use KaririCode\ProcessorPipeline\Exception\ProcessingException;
 use KaririCode\PropertyInspector\Contract\PropertyAttributeHandler;
 use KaririCode\PropertyInspector\Contract\PropertyChangeApplier;
+use KaririCode\PropertyInspector\Processor\ProcessorConfigBuilder;
 use KaririCode\PropertyInspector\Utility\PropertyAccessor;
 
 class AttributeHandler implements PropertyAttributeHandler, PropertyChangeApplier
 {
     private array $processedValues = [];
     private array $processingErrors = [];
+    private array $processingMessages = [];
 
     public function __construct(
         private readonly string $processorType,
         private readonly ProcessorBuilder $builder,
+        private readonly ProcessorConfigBuilder $configBuilder = new ProcessorConfigBuilder()
     ) {
     }
 
@@ -29,38 +31,65 @@ class AttributeHandler implements PropertyAttributeHandler, PropertyChangeApplie
             return null;
         }
 
-        $processors = $attribute->getProcessors();
+        $processorsConfig = $this->configBuilder->build($attribute);
+        $messages = $this->extractCustomMessages($attribute, $processorsConfig);
+
+        try {
+            $processedValue = $this->processValue($value, $processorsConfig);
+            $this->storeProcessedValue($propertyName, $processedValue, $messages);
+
+            return $processedValue;  // Return the processed value, not the original
+        } catch (\Exception $e) {
+            $this->storeProcessingError($propertyName, $e->getMessage());
+
+            return $value;
+        }
+    }
+
+    private function extractCustomMessages(ProcessableAttribute $attribute, array &$processorsConfig): array
+    {
+        $messages = [];
 
         if ($attribute instanceof CustomizableMessageAttribute) {
-            foreach ($processors as $processorName => &$config) {
+            foreach ($processorsConfig as $processorName => &$config) {
                 $customMessage = $attribute->getMessage($processorName);
                 if (null !== $customMessage) {
                     $config['customMessage'] = $customMessage;
+                    $messages[$processorName] = $customMessage;
                 }
             }
         }
 
-        $pipeline = $this->builder->buildPipeline($this->processorType, $processors);
+        return $messages;
+    }
 
-        try {
-            $processedValue = $pipeline->process($value);
-            $this->processedValues[$propertyName] = $processedValue;
+    private function processValue(mixed $value, array $processorsConfig): mixed
+    {
+        $pipeline = $this->builder->buildPipeline($this->processorType, $processorsConfig);
 
-            return $processedValue;
-        } catch (ProcessingException $e) {
-            $this->processingErrors[$propertyName][] = $e->getMessage();
+        return $pipeline->process($value);
+    }
 
-            return $value; // Return original value in case of processing error
-        }
+    private function storeProcessedValue(string $propertyName, mixed $processedValue, array $messages): void
+    {
+        $this->processedValues[$propertyName] = [
+            'value' => $processedValue,
+            'messages' => $messages,
+        ];
+        $this->processingMessages[$propertyName] = $messages;
+    }
+
+    private function storeProcessingError(string $propertyName, string $errorMessage): void
+    {
+        $this->processingErrors[$propertyName][] = $errorMessage;
     }
 
     public function applyChanges(object $entity): void
     {
-        foreach ($this->processedValues as $propertyName => $value) {
+        foreach ($this->processedValues as $propertyName => $data) {
             $accessor = new PropertyAccessor($entity, $propertyName);
-            $accessor->setValue($value);
+            $accessor->setValue($data['value']);
         }
-        $this->processedValues = []; // Clear the processed values after applying
     }
 
     public function getProcessedValues(): array

--- a/src/Processor/ProcessorConfigBuilder.php
+++ b/src/Processor/ProcessorConfigBuilder.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KaririCode\PropertyInspector\Processor;
+
+use KaririCode\Contract\Processor\Attribute\ProcessableAttribute;
+
+readonly class ProcessorConfigBuilder
+{
+    public function build(ProcessableAttribute $attribute): array
+    {
+        $processors = $attribute->getProcessors();
+        $processorsConfig = [];
+
+        foreach ($processors as $key => $processor) {
+            if ($this->isSimpleProcessor($processor)) {
+                $processorsConfig[$processor] = $this->getDefaultProcessorConfig();
+            } elseif ($this->isConfigurableProcessor($processor)) {
+                $processorName = $this->determineProcessorName($key, $processor);
+                $processorsConfig[$processorName] = $this->getProcessorConfig($processor);
+            }
+        }
+
+        return $processorsConfig;
+    }
+
+    private function isSimpleProcessor(mixed $processor): bool
+    {
+        return is_string($processor);
+    }
+
+    private function isConfigurableProcessor(mixed $processor): bool
+    {
+        return is_array($processor);
+    }
+
+    private function getDefaultProcessorConfig(): array
+    {
+        return [];
+    }
+
+    private function determineProcessorName(string|int $key, array $processor): string
+    {
+        $nameNormalizer = new ProcessorNameNormalizer();
+
+        return $nameNormalizer->normalize($key, $processor);
+    }
+
+    private function getProcessorConfig(array $processor): array
+    {
+        return $processor;
+    }
+}

--- a/src/Processor/ProcessorNameNormalizer.php
+++ b/src/Processor/ProcessorNameNormalizer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KaririCode\PropertyInspector\Processor;
+
+final readonly class ProcessorNameNormalizer
+{
+    public function normalize(string|int $key, array $processor): string
+    {
+        return $this->isNamedProcessor($key) ? (string) $key : $this->extractProcessorName($processor);
+    }
+
+    private function isNamedProcessor(string|int $key): bool
+    {
+        return is_string($key);
+    }
+
+    private function extractProcessorName(array $processor): string
+    {
+        $firstKey = array_key_first($processor);
+
+        return is_string($firstKey) ? $firstKey : '';
+    }
+}

--- a/tests/Processor/ProcessorConfigBuilderTest.php
+++ b/tests/Processor/ProcessorConfigBuilderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KaririCode\PropertyInspector\Tests\Processor;
+
+use KaririCode\Contract\Processor\Attribute\ProcessableAttribute;
+use KaririCode\PropertyInspector\Processor\ProcessorConfigBuilder;
+use PHPUnit\Framework\TestCase;
+
+class ProcessorConfigBuilderTest extends TestCase
+{
+    private ProcessorConfigBuilder $configBuilder;
+
+    protected function setUp(): void
+    {
+        $this->configBuilder = new ProcessorConfigBuilder();
+    }
+
+    public function testBuildWithSimpleProcessors(): void
+    {
+        $attribute = $this->createMock(ProcessableAttribute::class);
+        $attribute->method('getProcessors')->willReturn(['processor1', 'processor2']);
+
+        $result = $this->configBuilder->build($attribute);
+
+        $this->assertEquals(['processor1' => [], 'processor2' => []], $result);
+    }
+
+    public function testBuildWithConfigurableProcessors(): void
+    {
+        $attribute = $this->createMock(ProcessableAttribute::class);
+        $attribute->method('getProcessors')->willReturn([
+            'processor1' => ['option' => 'value'],
+            'processor2' => ['another_option' => 'another_value'],
+        ]);
+
+        $result = $this->configBuilder->build($attribute);
+
+        $this->assertEquals([
+            'processor1' => ['option' => 'value'],
+            'processor2' => ['another_option' => 'another_value'],
+        ], $result);
+    }
+
+    public function testBuildWithMixedProcessors(): void
+    {
+        $attribute = $this->createMock(ProcessableAttribute::class);
+        $attribute->method('getProcessors')->willReturn([
+            'processor1',
+            'processor2' => ['option' => 'value'],
+            ['unnamed_processor' => []],
+        ]);
+
+        $result = $this->configBuilder->build($attribute);
+
+        $this->assertEquals([
+            'processor1' => [],
+            'processor2' => ['option' => 'value'],
+            'unnamed_processor' => ['unnamed_processor' => []],
+        ], $result);
+    }
+}

--- a/tests/Processor/ProcessorNameNormalizerTest.php
+++ b/tests/Processor/ProcessorNameNormalizerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KaririCode\PropertyInspector\Tests\Processor;
+
+use KaririCode\PropertyInspector\Processor\ProcessorNameNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class ProcessorNameNormalizerTest extends TestCase
+{
+    private ProcessorNameNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new ProcessorNameNormalizer();
+    }
+
+    public function testNormalizeWithStringKey(): void
+    {
+        $result = $this->normalizer->normalize('processor_name', []);
+
+        $this->assertEquals('processor_name', $result);
+    }
+
+    public function testNormalizeWithIntegerKey(): void
+    {
+        $result = $this->normalizer->normalize(0, ['processor_name' => []]);
+
+        $this->assertEquals('processor_name', $result);
+    }
+
+    public function testNormalizeWithEmptyProcessor(): void
+    {
+        $result = $this->normalizer->normalize(0, []);
+
+        $this->assertEquals('', $result);
+    }
+}


### PR DESCRIPTION
… improved AttributeHandler

- Add creation of `ProcessorConfigBuilder` instance in the constructor and pass it to `AttributeHandler`.
- Update `AttributeHandler` to receive `ProcessorConfigBuilder` as an additional constructor parameter.
- Modify the `sanitize` method to use `AttributeHandler` methods for obtaining messages and processing errors, providing a richer and more informative return structure.
- Maintain the `sanitize` method signature to ensure compatibility with `SanitizerContract`.
- Ensure `PropertyInspector` continues to function as before, as main changes are encapsulated within `AttributeHandler`.

**Additional Considerations:**

- Updated unit tests for `Sanitizer` to reflect the new return structure and modified internal logic.
- Adjusted other classes that depend directly on `AttributeHandler` to accommodate similar changes.
- Verified that the new return structure of the `sanitize` method is compatible with the rest of the system, updating usage points as necessary.