### PR TITLE
refactor(PropertyInspector): update return type and error handling

### DIFF
--- a/src/Contract/PropertyInspector.php
+++ b/src/Contract/PropertyInspector.php
@@ -16,7 +16,7 @@ interface PropertyInspector
      *
      * @throws PropertyInspectionException If there's an error inspecting the object
      *
-     * @return array<string, array<int, mixed>> The inspection results
+     * @return PropertyAttributeHandler The inspection results
      */
-    public function inspect(object $object, PropertyAttributeHandler $handler): array;
+    public function inspect(object $object, PropertyAttributeHandler $handler): PropertyAttributeHandler;
 }

--- a/src/Utility/PropertyInspector.php
+++ b/src/Utility/PropertyInspector.php
@@ -15,26 +15,21 @@ final class PropertyInspector implements PropertyInspectorContract
     {
     }
 
-    public function inspect(object $object, PropertyAttributeHandler $handler): array
+    public function inspect(object $object, PropertyAttributeHandler $handler): PropertyAttributeHandler
     {
         try {
             $analysisResults = $this->attributeAnalyzer->analyzeObject($object);
-            $handledResults = [];
-
             foreach ($analysisResults as $propertyName => $propertyData) {
                 foreach ($propertyData['attributes'] as $attribute) {
-                    $result = $handler->handleAttribute($propertyName, $attribute, $propertyData['value']);
-                    if (null !== $result) {
-                        $handledResults[$propertyName][] = $result;
-                    }
+                    $handler->handleAttribute($propertyName, $attribute, $propertyData['value']);
                 }
             }
 
-            return $handledResults;
+            return $handler;
         } catch (\ReflectionException $e) {
             throw new PropertyInspectionException('Failed to analyze object: ' . $e->getMessage(), 0, $e);
         } catch (\Exception $e) {
-            throw new PropertyInspectionException('An error occurred during object analysis: ' . $e->getMessage(), 0, $e);
+            throw new PropertyInspectionException('An exception occurred during object analysis: ' . $e->getMessage(), 0, $e);
         } catch (\Error $e) {
             throw new PropertyInspectionException('An error occurred during object analysis: ' . $e->getMessage(), 0, $e);
         }


### PR DESCRIPTION
- Change PropertyInspector::inspect() to return PropertyAttributeHandler
- Update PropertyInspectorTest to reflect new return type and behavior
- Add additional tests for exception and error handling
- Remove obsolete test cases